### PR TITLE
Feat : 인벤토리 버그 해결

### DIFF
--- a/src/db/user/user.db.js
+++ b/src/db/user/user.db.js
@@ -219,7 +219,7 @@ export const syncInventoryToRedisAndSend = async (playerId) => {
         redisKey,
         row.slot_idx.toString(),
         JSON.stringify({
-          itemId: row.item_id,
+          itemId: row.item_id == null ? 0 : row.item_id,
           stack: row.stack,
         }),
       );


### PR DESCRIPTION
- Town에서 최초 1회 인벤토리를 열지 않고 Sector 이동을 해도 인벤토리를 사용할 수 있습니다.
- 인벤토리에 아이템이 전혀 없을 때, 자원을 채취해도 아이템이 들어오지 않던 현상을 해결했습니다.