### PR TITLE
bugfix: 레벨업 버그 해결

### DIFF
--- a/src/classes/player.class.js
+++ b/src/classes/player.class.js
@@ -173,10 +173,10 @@ class Player {
   }
 
   levelUp() {
-    const { newLevel, newTargetExp } = this._getTargetExpByLevel(this.level);
+    const { targetLevel, targetExp } = this._getTargetExpByLevel(this.level);
 
     // 만렙이면 level만 올리고 요구 경험치 2배로
-    if (newLevel === -1) {
+    if (targetLevel === -1) {
       this.level += 1;
       this.targetExp *= 2;
       this.abilityPoint += 3;
@@ -188,13 +188,17 @@ class Player {
     }
 
     // 레벨, 요구 경험치 변경
-    this.level = newLevel;
-    this.targetExp = newTargetExp;
+    this.level = targetLevel;
+    this.targetExp = targetExp;
 
     // 레벨업하면 올릴 수 있는 능력치 개수
     this.abilityPoint += 3;
 
-    return { newLevel, newTargetExp, abilityPoint: this.abilityPoint };
+    return {
+      newLevel: this.level,
+      newTargetExp: this.targetExp,
+      abilityPoint: this.abilityPoint,
+    };
   }
 
   setCurrentEquip(equipment) {


### PR DESCRIPTION
- this._getTargetExpByLevel(level) 메서드는 { targetLevel: data.targetLevel, targetExp: data.target_exp }를 반환하고 있는데, 그걸 분해 할당할 때는 { newLevel, newTargetExp }로 받고 있었기 때문에 레벨업이 안 됐던 겁니다.
- 오랫동안 알려진 버그였고 디버그 한 번만 해보면 고칠 수 있었어요. 다들 유심히 코드를 살펴봐 주세요. 제발요...!