### PR TITLE
feat: 패킷 크기 제한 완화

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -196,7 +196,7 @@ export const config = {
   },
   blacklist: {
     MAX_REQUESTS_PER_SECOND: 70,
-    MAX_PACKET_SIZE: 1024,
+    MAX_PACKET_SIZE: 5000,
   },
 };
 


### PR DESCRIPTION
- 인벤토리 정렬 시 튕기던 걸 막아보고자 패킷 크기 제한을 완화했습니다.(이게 원인인지는 모릅니다.)